### PR TITLE
Add logic for handling components that use wit-bindgen 0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "adapter"]
 	path = adapter
 	url = https://github.com/dicej/preview1.wasm
+[submodule "preview2-prototyping"]
+	path = preview2-prototyping
+	url = https://github.com/bytecodealliance/preview2-prototyping

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
  "wasi-cap-std-sync",
  "wasi-common",
  "wasm-encoder 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.102.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.102.0",
  "wasmtime",
  "wit-component",
 ]
@@ -1525,21 +1525,21 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.25.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.3.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.4.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "anyhow",
  "indexmap",
  "serde",
- "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
- "wasmparser 0.102.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
+ "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855)",
+ "wasmparser 0.103.0",
 ]
 
 [[package]]
@@ -1564,8 +1564,8 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.103.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "indexmap",
  "url",
@@ -1578,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc17ae63836d010a2bf001c26a5fedbb9a05e5f71117fb63e0ab878bfbe1ca3"
 dependencies = [
  "anyhow",
- "wasmparser 0.102.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.102.0",
 ]
 
 [[package]]
@@ -1656,7 +1656,7 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.6.4",
 ]
 
 [[package]]
@@ -1814,7 +1814,7 @@ checksum = "fd2cf93f3c8a6f443d8a9098fddc5fd887783c0fe725dc10c54ca9280546421d"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.6.4",
 ]
 
 [[package]]
@@ -1963,18 +1963,18 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.7.4"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.8.1"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
  "indexmap",
  "log",
  "url",
- "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
+ "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855)",
  "wasm-metadata",
- "wasmparser 0.102.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
- "wit-parser 0.6.4 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
+ "wasmparser 0.103.0",
+ "wit-parser 0.7.0",
 ]
 
 [[package]]
@@ -1994,8 +1994,8 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.6.4"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.7.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2021"
 anyhow = "1.0.69"
 wasmparser = "0.102.0"
 wasm-encoder = "0.25.0"
-# TODO: switch to release once https://github.com/bytecodealliance/wasm-tools/pull/965 has been released
-wit-component = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "1e0052974277b3cce6c3703386e4e90291da2b24" }
+wit-component = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "016838279808be4d257f1b58b9942420f0a09855" }
 
 [dev-dependencies]
 anyhow = "1.0.69"

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,21 @@ fn main() {
 
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
+        .current_dir("preview2-prototyping")
+        .arg("--release")
+        .arg("--target=wasm32-unknown-unknown")
+        .env("CARGO_TARGET_DIR", &out_dir);
+    let status = cmd.status().unwrap();
+    assert!(status.success());
+    println!("cargo:rerun-if-changed=preview2-prototyping");
+    fs::rename(
+        out_dir.join("wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm"),
+        out_dir.join("wasm32-unknown-unknown/release/wasi_snapshot_preview1_upstream.wasm"),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
         .current_dir("adapter")
         .arg("--release")
         .arg("--no-default-features")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 use {
-    anyhow::{anyhow, Result},
+    anyhow::{anyhow, Context, Result},
     convert::{IntoEntityType, IntoExportKind},
     std::{borrow::Cow, collections::HashSet},
     wasm_encoder::{CustomSection, ExportSection, ImportSection, Module, RawSection},
@@ -35,60 +35,66 @@ static EXPORT_INTERFACES: &[(&str, &str)] = &[
 ];
 
 pub fn componentize_if_necessary(module_or_component: &[u8]) -> Result<Cow<[u8]>> {
-    // Spin can handle three types of spin components: wasm components, core modules
-    // built with wit-bindgen 0.2, and core modules built with wit-bindgen 0.5
-    enum SpinEncoding {
-        Component,
-        Module02,
-        Module05,
-    }
-    let mut encoding = None;
     for payload in Parser::new(0).parse_all(module_or_component) {
-        match payload? {
-            Payload::Version { encoding: e, .. } if e == Encoding::Component => {
-                encoding = Some(SpinEncoding::Component);
-                break;
-            }
-            Payload::Version { encoding: e, .. } if e == Encoding::Module => {
-                encoding = Some(SpinEncoding::Module02)
-            }
-            Payload::ExportSection(s) => {
-                for e in s {
-                    if let Some(suffix) = e?.name.strip_prefix("spin-sdk-version-") {
-                        let mut parts = suffix.split('-');
-                        let major = parts.next();
-                        let minor = parts.next();
-                        let patch = parts.next().and_then(|s| s.strip_prefix("pre"));
-                        let test = |str: &str, min: usize| str.parse::<usize>().ok() >= Some(min);
-                        match (major, minor, patch) {
-                            (Some(maj), _, _) if test(maj, 2) => {}
-                            (Some(maj), Some(min), _) if test(maj, 1) && test(min, 3) => {}
-                            (Some(maj), Some(min), Some(patch))
-                                if test(maj, 1) && test(min, 2) && test(patch, 0) => {}
-                            _ => break,
-                        }
-                        encoding = Some(SpinEncoding::Module05);
-                        break;
-                    }
-                }
+        match payload.context("unable to parse binary")? {
+            Payload::Version { encoding, .. } => {
+                return match encoding {
+                    Encoding::Component => Ok(Cow::Borrowed(module_or_component)),
+                    Encoding::Module => componentize(module_or_component).map(Cow::Owned),
+                };
             }
             _ => (),
         }
     }
-    match encoding {
-        Some(SpinEncoding::Component) => Ok(Cow::Borrowed(module_or_component)),
-        Some(SpinEncoding::Module02) => componentize(module_or_component).map(Cow::Owned),
-        Some(SpinEncoding::Module05) => ComponentEncoder::default()
-            .validate(true)
-            .module(&module_or_component)?
-            .adapter("wasi_snapshot_preview1", PREVIEW1_ADAPTER)?
-            .encode()
-            .map(Cow::Owned),
-        None => Err(anyhow!("unable to determine Wasm encoding")),
-    }
+    Err(anyhow!("unable to determine wasm binary encoding"))
 }
 
 pub fn componentize(module: &[u8]) -> Result<Vec<u8>> {
+    match WitBindgenVersion::from_module(module)? {
+        WitBindgenVersion::V0_2 => componentize_bindgen0_2(module),
+        WitBindgenVersion::V0_5 => componentize_bindgen0_5(module),
+        WitBindgenVersion::Other(other) => Err(anyhow::anyhow!(
+            "cannot adapt modules created with wit-bindgen version {other}"
+        )),
+    }
+}
+
+/// In order to properly componentize modules, we need to know which
+/// version of wit-bindgen was used
+enum WitBindgenVersion {
+    V0_5,
+    V0_2,
+    Other(String),
+}
+
+impl WitBindgenVersion {
+    fn from_module(module: &[u8]) -> Result<Self> {
+        let (_, bindgen) = metadata::decode(module)?;
+        if let Some(producers) = bindgen.producers {
+            if let Some(processors) = producers.get("processed-by") {
+                match processors.get("wit-bindgen-rust").map(|s| s.as_str()) {
+                    Some("0.5.0") => return Ok(Self::V0_5),
+                    Some(other) => return Ok(Self::Other(other.to_owned())),
+                    None => {}
+                }
+            }
+        }
+
+        Ok(Self::V0_2)
+    }
+}
+
+/// Modules produced with wit-bindgen 0.5 only need wasi preview 1 to preview 2 adapter
+pub fn componentize_bindgen0_5(module: &[u8]) -> Result<Vec<u8>> {
+    ComponentEncoder::default()
+        .validate(true)
+        .module(&module)?
+        .adapter("wasi_snapshot_preview1", PREVIEW1_ADAPTER)?
+        .encode()
+}
+
+/// Modules produced with wit-bindgen 0.2 need more extensive adaption
+pub fn componentize_bindgen0_2(module: &[u8]) -> Result<Vec<u8>> {
     let (module, exports) = retarget_imports_and_get_exports(ADAPTER_NAME, module)?;
 
     let (adapter, mut bindgen) = metadata::decode(SPIN_ADAPTER)?;


### PR DESCRIPTION
This allows adapting of spin components that are [built using wit-bindgen 0.5](https://github.com/fermyon/spin/pull/1424) .

This brings in another submodule dependency on the wasi-preview2 upstream project since we want to use an unmodified form of it for these new module types. 

A few things need to be done before we merge:
* [x] Move to using the wit-component embedded ABI version information to make a decision about what adapter to apply
* [ ] Test whether the latest version of wasi-preview2 is compatible with the version we're using in the `adapter` fork. If so, we can rebase the adapter changes to this latest version.
