### PR TITLE
The new componentization route works for wit-bindgen 0.6 as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@ pub fn componentize_if_necessary(module_or_component: &[u8]) -> Result<Cow<[u8]>
 
 pub fn componentize(module: &[u8]) -> Result<Vec<u8>> {
     match WitBindgenVersion::from_module(module)? {
-        WitBindgenVersion::V0_2 => componentize_bindgen0_2(module),
-        WitBindgenVersion::V0_5 => componentize_bindgen0_5(module),
+        WitBindgenVersion::V0_2 => componentize_old_bindgen(module),
+        WitBindgenVersion::V0_5 | WitBindgenVersion::V0_6 => componentize_new_bindgen(module),
         WitBindgenVersion::Other(other) => Err(anyhow::anyhow!(
             "cannot adapt modules created with wit-bindgen version {other}"
         )),
@@ -63,6 +63,7 @@ pub fn componentize(module: &[u8]) -> Result<Vec<u8>> {
 /// version of wit-bindgen was used
 #[derive(Debug)]
 enum WitBindgenVersion {
+    V0_6,
     V0_5,
     V0_2,
     Other(String),
@@ -77,6 +78,7 @@ impl WitBindgenVersion {
                     key.starts_with("wit-bindgen").then(|| value.as_str())
                 });
                 match bindgen_version {
+                    Some(v) if v.starts_with("0.6.") => return Ok(Self::V0_6),
                     Some(v) if v.starts_with("0.5.") => return Ok(Self::V0_5),
                     Some(other) => return Ok(Self::Other(other.to_owned())),
                     None => {}
@@ -88,8 +90,8 @@ impl WitBindgenVersion {
     }
 }
 
-/// Modules produced with wit-bindgen 0.5 only need wasi preview 1 to preview 2 adapter
-pub fn componentize_bindgen0_5(module: &[u8]) -> Result<Vec<u8>> {
+/// Modules produced with wit-bindgen 0.5 and newer only need wasi preview 1 to preview 2 adapter
+pub fn componentize_new_bindgen(module: &[u8]) -> Result<Vec<u8>> {
     ComponentEncoder::default()
         .validate(true)
         .module(&module)?
@@ -98,7 +100,7 @@ pub fn componentize_bindgen0_5(module: &[u8]) -> Result<Vec<u8>> {
 }
 
 /// Modules produced with wit-bindgen 0.2 need more extensive adaption
-pub fn componentize_bindgen0_2(module: &[u8]) -> Result<Vec<u8>> {
+pub fn componentize_old_bindgen(module: &[u8]) -> Result<Vec<u8>> {
     let (module, exports) = retarget_imports_and_get_exports(ADAPTER_NAME, module)?;
 
     let (adapter, mut bindgen) = metadata::decode(SPIN_ADAPTER)?;


### PR DESCRIPTION
Tested with the very latest version of wit-bindgen and things work as expected.