### PR TITLE
Allow wit-bindgen 0.4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub fn componentize_if_necessary(module_or_component: &[u8]) -> Result<Cow<[u8]>
 
 pub fn componentize(module: &[u8]) -> Result<Vec<u8>> {
     match WitBindgenVersion::from_module(module)? {
-        WitBindgenVersion::V0_2 => componentize_old_bindgen(module),
+        WitBindgenVersion::V0_2 | WitBindgenVersion::V0_4 => componentize_old_bindgen(module),
         WitBindgenVersion::V0_5 | WitBindgenVersion::V0_6 => componentize_new_bindgen(module),
         WitBindgenVersion::Other(other) => Err(anyhow::anyhow!(
             "cannot adapt modules created with wit-bindgen version {other}"
@@ -65,6 +65,7 @@ pub fn componentize(module: &[u8]) -> Result<Vec<u8>> {
 enum WitBindgenVersion {
     V0_6,
     V0_5,
+    V0_4,
     V0_2,
     Other(String),
 }
@@ -80,6 +81,7 @@ impl WitBindgenVersion {
                 match bindgen_version {
                     Some(v) if v.starts_with("0.6.") => return Ok(Self::V0_6),
                     Some(v) if v.starts_with("0.5.") => return Ok(Self::V0_5),
+                    Some(v) if v.starts_with("0.4.") => return Ok(Self::V0_4),
                     Some(other) => return Ok(Self::Other(other.to_owned())),
                     None => {}
                 }


### PR DESCRIPTION
One test in spin is using `wit-bindgen` 0.4. Since that test shows some evidence that the "old" `spin-componentize` code path works for spin components using 0.4, I think it's safe to add the support here. This would fix the failing test in https://github.com/fermyon/spin/pull/1433.