### PR TITLE
Remove building tests from test script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 fn main() {
@@ -29,35 +28,4 @@ fn main() {
         out_dir.join("wasm32-unknown-unknown/release/wasi_snapshot_preview1_command.wasm"),
     )
     .unwrap();
-
-    build_rust_test_case(&out_dir, "rust-case-0.2");
-    build_rust_test_case(&out_dir, "rust-case-0.8");
-    build_rust_test_case(&out_dir, "rust-command");
-
-    let mut cmd = Command::new("tinygo");
-    cmd.arg("build")
-        .current_dir("tests/go-case")
-        .arg("-target=wasi")
-        .arg("-gc=leaking")
-        .arg("-no-debug")
-        .arg("-o")
-        .arg(out_dir.join("go_case.wasm"))
-        .arg("main.go");
-
-    // If just skip this if TinyGo is not installed
-    _ = cmd.status();
-    println!("cargo:rerun-if-changed=tests/go-case");
-}
-
-fn build_rust_test_case(out_dir: &PathBuf, name: &str) {
-    let mut cmd = Command::new("cargo");
-    cmd.arg("build")
-        .current_dir(&format!("tests/{name}"))
-        .arg("--release")
-        .arg("--target=wasm32-wasi")
-        .env("CARGO_TARGET_DIR", out_dir);
-
-    let status = cmd.status().unwrap();
-    assert!(status.success());
-    println!("cargo:rerun-if-changed=tests/{name}");
 }

--- a/tests/rust-case-0.2/src/lib.rs
+++ b/tests/rust-case-0.2/src/lib.rs
@@ -355,7 +355,7 @@ fn execute(body: Option<Vec<u8>>) -> Result<()> {
             key_value::close(*store);
         }
         Command::LlmInfer { model, prompt } => {
-            llm::infer(model, prompt, None);
+            let _ = llm::infer(model, prompt, None);
         }
 
         Command::WasiEnv { key } => Command::env(key.clone())?,

--- a/tests/rust-case-0.8/src/lib.rs
+++ b/tests/rust-case-0.8/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use case_helper::Command;
 use spin::http_types::{Method, Request, Response};
 use std::{
@@ -261,7 +261,7 @@ fn execute(body: Option<Vec<u8>>) -> Result<()> {
             spin::key_value::close(store);
         }
         Command::LlmInfer { model, prompt } => {
-            spin::llm::infer(&model, &prompt, None);
+            let _ = spin::llm::infer(&model, &prompt, None);
         }
 
         Command::WasiEnv { key } => Command::env(key)?,


### PR DESCRIPTION
The spin-componentize build script can takes upwards of 60 seconds to run which is wasted time in builds where the tests are not going to be run. This moves test binary building to the tests themselves. 