### PR TITLE
Update wit-parser to 0.12.1 and wit-component to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,7 +1393,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wit-component",
- "wit-parser 0.12.0",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -2387,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1bc644bb4205a2ee74035e5d35958777575fa4c6dd38ce7226c7680be2861c1"
+checksum = "e87488b57a08e2cbbd076b325acbe7f8666965af174d69d5929cd373bd54547f"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -2401,7 +2401,7 @@ dependencies = [
  "wasm-encoder 0.35.0",
  "wasm-metadata",
  "wasmparser 0.115.0",
- "wit-parser 0.12.0",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -2424,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08c9557c65c428ac18a3cce80bf2527dbec24ab06639642c7db73f2c7613f93"
+checksum = "f6ace9943d89bbf3dbbc71b966da0e7302057b311f36a4ac3d65ddfef17b52cf"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 anyhow = "1.0.71"
 wasmparser = "0.115.0"
 wasm-encoder = "0.35.0"
-wit-component = "0.15.0"
-wit-parser = "0.12.0"
+wit-component = "0.16.0"
+wit-parser = "0.12.1"
 
 [dev-dependencies]
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "c796ce7376a57a40605f03e74bd78cefcc9acf3a", features = [


### PR DESCRIPTION
This is required by the latest version of the wasmtime 14.0.0 branch. 